### PR TITLE
♻️ refactor: CurrencyList 화면 구성 MVC 구조로 분리

### DIFF
--- a/HwanYulApp/View/CurrencyListView.swift
+++ b/HwanYulApp/View/CurrencyListView.swift
@@ -1,0 +1,38 @@
+//
+//  Untitled.swift
+//  HwanYulApp
+//
+//  Created by 서광용 on 7/9/25.
+//
+
+import UIKit
+import SnapKit
+
+final class CurrencyListView: UIView {
+  
+  let tableView: UITableView = {
+    let tableView = UITableView()
+    tableView.rowHeight = 60 // 2줄에 아이콘도 있기에 Cell 크기를 60 고정
+    tableView.register(CurrencyListCell.self, forCellReuseIdentifier: CurrencyListCell.identifier)
+    return tableView
+  }()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configureUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - configureUI
+  private func configureUI() {
+    backgroundColor = .white
+    addSubview(tableView)
+    
+    tableView.snp.makeConstraints {
+      $0.directionalEdges.equalToSuperview()
+    }
+  }
+}

--- a/HwanYulApp/ViewController/CurrencyListViewController.swift
+++ b/HwanYulApp/ViewController/CurrencyListViewController.swift
@@ -9,15 +9,8 @@ import UIKit
 
 class CurrencyListViewController: UIViewController {
   
+  private let currencyListView = CurrencyListView()
   private var dataSource: [CurrencyItem] = [] // 튜플을 여러개 담은 배열
-  
-  private lazy var tableView: UITableView = {
-    let tableView = UITableView()
-    tableView.dataSource = self
-    tableView.delegate = self
-    tableView.register(CurrencyListCell.self, forCellReuseIdentifier: CurrencyListCell.identifier)
-    return tableView
-  }()
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -28,12 +21,14 @@ class CurrencyListViewController: UIViewController {
   // MARK: - configureUI
   private func configureUI() {
     view.backgroundColor = .white
-    view.addSubview(tableView)
-    tableView.rowHeight = 60 // 2줄에 아이콘도 있기에 Cell 크기를 60 고정
+    view.addSubview(currencyListView)
     
-    tableView.snp.makeConstraints {
+    currencyListView.snp.makeConstraints {
       $0.directionalEdges.equalTo(view.safeAreaLayoutGuide)
     }
+    
+    currencyListView.tableView.dataSource = self
+    currencyListView.tableView.delegate = self
   }
   
   // MARK: - fetchAndBindCurrencyData
@@ -50,7 +45,7 @@ class CurrencyListViewController: UIViewController {
         } else {
           // 소문자로 변경해서 반복 비교
           self.dataSource = currency.items.sorted { $0.code.lowercased() < $1.code.lowercased() }
-          self.tableView.reloadData() // UI랑 관련있는 UI 업데이트라 메인 스레드에서 수행
+          self.currencyListView.tableView.reloadData() // UI랑 관련있는 UI 업데이트라 메인 스레드에서 수행
         }
       }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- #4 

## 🔧 PR 요약
- CurrencyListViewController에서 UITableView를 CurrencyListView로 분리
- ViewController는 view 제어에 집중하고, View는 UI 구성만 담당
- tableView의 delegate 및 dataSource는 VC에서 설정

## ✅ 작업 내용 체크리스트
- [x] CurrencyListView라는 새로운 UIView 생성
- [x] 기준 tableView 생성/레이아웃 코드를 CurrencyListView로 이동
- [x] tableView.delegate, tableView.dataSource를 ViewController에서 설정

## 📸 스크린샷 (선택)

## 📎 기타 참고사항