### PR TITLE
✨ Level7, 9 - 즐겨찾기 기능 및 다크모드 대응 구현 완료 

### DIFF
--- a/HwanYulApp/App/CoreData/CoreDataManager.swift
+++ b/HwanYulApp/App/CoreData/CoreDataManager.swift
@@ -1,0 +1,75 @@
+//
+//  CoreDataManager.swift
+//  HwanYulApp
+//
+//  Created by 서광용 on 7/13/25.
+//
+
+import UIKit
+import CoreData
+
+final class CoreDataManager {
+  static let shared = CoreDataManager()
+  private init() {} // 왜홰?
+  
+  /*
+   
+   1. CurrencyDataModel.xcdatamodeld
+      ↓
+   2. NSPersistentContainer 생성 (CurrencyDataModel 기반)
+      ↓
+   3. 저장소 로드 or 생성
+      ↓
+   4. context (작업 공간) 생성
+      ↓
+   5. context를 통해 데이터 추가/삭제/조회/저장
+   
+   ---
+   
+   CurrencyDatamodel이라는 파일을 기반으로, container라는 데이터베이스를 만듦
+   
+   걔를 로딩하고, 그 위에 context릘 띄운다.
+   
+   */
+  
+  lazy var persistentContainer: NSPersistentContainer = {
+    // container 생성 (딱 1개만)
+    let container = NSPersistentContainer(name: "CurrencyDataModel")
+    // 저장소 load
+    container.loadPersistentStores { _, error in
+      if let error = error {
+        fatalError("CoreData 로드 실패: \(error)")
+      }
+    }
+    return container
+  }()
+  
+  // MARK: - Context 작업 공간
+  // NSManagedObjectContext: CoreData의 작업 공간(열려 있느 엑셀 창)
+  // CoreData에 데이터를 추가/삭제/조회/수정 때는 반드시 이 context를 통해서만 가능
+  // 이 context에서 임시로 조작하다가, save()하면 실제 DB에 반영
+  var context: NSManagedObjectContext {
+    return persistentContainer.viewContext
+  }
+  
+  // MARK: - 즐겨찾기 추가
+  func addFavorite(code: String) {
+    // 이미 있는 context에 FavoriteCurrency라는 데이터를 추가함
+    let favorite = FavoriteCurrency(context: context)
+    favorite.code = code
+    saveContext()
+  }
+  
+  
+  // MARK: - Context 저장
+  private func saveContext() {
+    if context.hasChanges { // hasChanges: 저장되지 않은 변경사항이 있는지 확인하는 Bool값
+      do {
+        // 변경된 내용 저장
+        try context.save()
+      } catch {
+        print("저장 실패")
+      }
+    }
+  }
+}

--- a/HwanYulApp/App/CoreData/CoreDataManager.swift
+++ b/HwanYulApp/App/CoreData/CoreDataManager.swift
@@ -56,6 +56,19 @@ final class CoreDataManager {
     }
   }
   
+  // MARK: - 즐겨찾기 목록 전체 가져오기
+  func fetchAllFavoriteCodes() -> [String] {
+    let requset: NSFetchRequest<FavoriteCurrency> = FavoriteCurrency.fetchRequest()
+    
+    do {
+      let results = try context.fetch(requset)
+      return results.compactMap { $0.code }
+    } catch {
+      print("불러오기 실패: \(error)")
+      return []
+    }
+  }
+  
   // MARK: - Context 저장
   private func saveContext() {
     if context.hasChanges { // hasChanges: 저장되지 않은 변경사항이 있는지 확인하는 Bool값

--- a/HwanYulApp/App/CoreData/CurrencyDataModel.xcdatamodeld/CurrencyDataModel.xcdatamodel/contents
+++ b/HwanYulApp/App/CoreData/CurrencyDataModel.xcdatamodeld/CurrencyDataModel.xcdatamodel/contents
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="FavoriteCurrency" representedClassName="FavoriteCurrency" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/HwanYulApp/App/CoreData/FavoriteCurrency+CoreDataClass.swift
+++ b/HwanYulApp/App/CoreData/FavoriteCurrency+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  FavoriteCurrency+CoreDataClass.swift
+//  HwanYulApp
+//
+//  Created by 서광용 on 7/13/25.
+//
+// NSManagedObject: Core Data 엔티티와의 상호작용을 관리하며, 속성 값의 저장 및 검색을 처리
+
+import Foundation
+import CoreData
+
+@objc(FavoriteCurrency)
+public class FavoriteCurrency: NSManagedObject {
+  
+}

--- a/HwanYulApp/App/CoreData/FavoriteCurrency+CoreDataProperties.swift
+++ b/HwanYulApp/App/CoreData/FavoriteCurrency+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  FavoriteCurrency+CoreDataProperties.swift
+//  HwanYulApp
+//
+//  Created by 서광용 on 7/13/25.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension FavoriteCurrency {
+  
+  // nonobjc: obj-c 동작안하고, swift에서만 동작
+  @nonobjc public class func fetchRequest() -> NSFetchRequest<FavoriteCurrency> {
+    return NSFetchRequest<FavoriteCurrency>(entityName: "FavoriteCurrency")
+  }
+  
+  // @NSManaged: CoreData에 관리되는 객체를 의미
+  @NSManaged public var code: String?
+  
+}
+
+// FavoriteCurrency 타입이 고유하게 식별될 수 있음을 의미
+extension FavoriteCurrency : Identifiable {
+  
+}

--- a/HwanYulApp/Model/CurrencyItem.swift
+++ b/HwanYulApp/Model/CurrencyItem.swift
@@ -14,6 +14,8 @@ struct CurrencyItem {
   var countryName: String {
     CurrencyCountryMap.mapping[code] ?? "데이터에 없는 나라입니다."
   }
+  
+  var isFavorite: Bool = false
 }
 
 // MARK: Currency -> [CurrencyItem]으로 변환

--- a/HwanYulApp/View/CurrencyListCell.swift
+++ b/HwanYulApp/View/CurrencyListCell.swift
@@ -60,6 +60,8 @@ final class CurrencyListCell: UITableViewCell {
   
   // MARK: - configureViews
   private func configureViews() {
+    backgroundColor = .clear
+    contentView.backgroundColor = .systemBackground
     [labelStackView, currencyRateLabel, isStarButton].forEach {
       contentView.addSubview($0)
     }

--- a/HwanYulApp/View/CurrencyListCell.swift
+++ b/HwanYulApp/View/CurrencyListCell.swift
@@ -13,6 +13,8 @@ final class CurrencyListCell: UITableViewCell {
   static let identifier = "CurrencyListCell"
   static let height: CGFloat = 60
   
+  var onStarTapped: (() -> Void)?
+  
   private let labelStackView: UIStackView = {
     let stackView = UIStackView()
     stackView.axis = .vertical
@@ -39,10 +41,17 @@ final class CurrencyListCell: UITableViewCell {
     return label
   }()
   
+  private let isStarButton: UIButton = {
+    let button = UIButton()
+    button.tintColor = .systemYellow
+    return button
+  }()
+  
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super .init(style: style, reuseIdentifier: reuseIdentifier)
     configureViews()
     configureLayout()
+    setupActions()
   }
   
   required init?(coder: NSCoder) {
@@ -51,7 +60,7 @@ final class CurrencyListCell: UITableViewCell {
   
   // MARK: - configureViews
   private func configureViews() {
-    [labelStackView, currencyRateLabel].forEach {
+    [labelStackView, currencyRateLabel, isStarButton].forEach {
       contentView.addSubview($0)
     }
     
@@ -69,8 +78,13 @@ final class CurrencyListCell: UITableViewCell {
     
     currencyRateLabel.snp.makeConstraints {
       $0.centerY.equalToSuperview()
-      $0.trailing.equalToSuperview().inset(16)
+      $0.trailing.equalTo(isStarButton.snp.leading).offset(-12)
       $0.leading.greaterThanOrEqualTo(labelStackView.snp.trailing).offset(16)
+    }
+    
+    isStarButton.snp.makeConstraints {
+      $0.centerY.equalToSuperview()
+      $0.trailing.equalToSuperview().inset(16)
     }
   }
   
@@ -78,5 +92,16 @@ final class CurrencyListCell: UITableViewCell {
     currencyCodeLabel.text = "\(currency.code)"
     currencyRateLabel.text = String(format: "%.4f", currency.rate)
     countryNameLabel.text = "\(currency.countryName)"
+    
+    let imageName = currency.isFavorite ? "star.fill" : "star"
+    isStarButton.setImage(UIImage(systemName: imageName), for: .normal)
+  }
+  
+  private func setupActions() {
+    isStarButton.addTarget(self, action: #selector(starButtonTapped), for: .touchUpInside)
+  }
+  
+  @objc private func starButtonTapped() {
+    onStarTapped?()
   }
 }

--- a/HwanYulApp/View/CurrencyListViewController.swift
+++ b/HwanYulApp/View/CurrencyListViewController.swift
@@ -44,7 +44,7 @@ class CurrencyListViewController: UIViewController {
   }()
   
   private let viewModel = CurrencyListViewModel()
-  private var items: [CurrencyItem] = [] // 이렇게 변수를 직접 VC가 가지고 있어도 괜찮은건가..
+  private var items: [CurrencyItem] = []
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -116,6 +116,12 @@ extension CurrencyListViewController: UITableViewDataSource {
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     guard let cell = tableView.dequeueReusableCell(withIdentifier: CurrencyListCell.identifier) as? CurrencyListCell else { return UITableViewCell() }
     cell.configureCell(currency: items[indexPath.row])
+    cell.onStarTapped = { [weak self] in
+      guard let self else { return }
+      
+      let item = items[indexPath.row]
+      self.viewModel.action(.toggleFavorite(item))
+    }
     return cell
   }
 }

--- a/HwanYulApp/ViewModel/CurrencyListViewModel.swift
+++ b/HwanYulApp/ViewModel/CurrencyListViewModel.swift
@@ -10,6 +10,7 @@
 enum CurrencyListAction { // View(VC)가 ViewModel에게 동작을 해달라 요청.
   case loadData
   case search(String)
+  case toggleFavorite(CurrencyItem)
 }
 
 enum CurrencyListState {
@@ -37,6 +38,8 @@ final class CurrencyListViewModel: ViewModelProtocol {
       fetchCurrencyData()
     case .search(let keyword):
       filterCurrency(keyword: keyword)
+    case .toggleFavorite(let item): // item에는 몇번째 셀이 눌린건지에 대한 정보
+      toggleFavorite(item)
     }
   }
   
@@ -62,5 +65,21 @@ final class CurrencyListViewModel: ViewModelProtocol {
       }
       self.state = .success(filtered)
     }
+  }
+  
+  private func toggleFavorite(_ item: CurrencyItem) {
+    guard let index = allCurrencyItems.firstIndex(where: { $0.code == item.code}) else { return }
+    
+    allCurrencyItems[index].isFavorite.toggle()
+    
+    let sorted = allCurrencyItems.sorted {
+      if $0.isFavorite == $1.isFavorite { // 즐겨찾기된 데이터들 알파벳 오름차순 정렬
+        return $0.code < $1.code
+      } else { // 아니라면 즐겨찾기 데이터 먼저 배치
+        return $0.isFavorite && !$1.isFavorite
+      }
+    }
+    
+    self.state = .success(sorted)
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- #15 

## 🔧 PR 요약
- 즐겨찾기 기능 및 다크모드 대응을 구현했습니다.

## ✅ 작업 내용 체크리스트
- [x] 즐겨찾기 기능 추가: 통화 데이터를 CoreData에 저장 및 삭제
- [x] 셀 우측에 ⭐ / ☆ 버튼 UI 구현 및 상태 연동
- [x] 즐겨찾기된 통화는 리스트 상단에 정렬되도록 정렬 로직 적용 (즐겨찾기 내 알파벳 정렬 포함)
- [x] 시스템 색상(label, secondaryLabel, systemBackground 등) 적용하여 다크모드 대응
- [x] UITableViewCell의 contentView에 systemBackground 적용하여 깔끔하게 전환

## 📸 스크린샷 (선택)
![Simulator Screen Recording - iPhone 16 Pro Max - 2025-07-13 at 19 12 34](https://github.com/user-attachments/assets/182ad720-3c59-4034-a206-e546e6f48358)


## 📎 기타 참고사항

